### PR TITLE
Feat/add helpers

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,11 @@
 use jsonrpsee::{core::ClientError, types::ErrorObject};
 use thiserror::Error;
 use tracing::error;
+use serde::Serialize;
 
 // shoutout chatgpt ^^
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Serialize)]
 pub enum AoriBackendErrors {
     #[error("Your JSON-RPC payload data doesn't fit into the correct format")]
     IncorrectRequestFormat(),


### PR DESCRIPTION
- Added `Serialize` to `AoriBackendErrors` 
- Added 3 functions that are in aori-sdk-ts to `shared_types.rs` to help with rfq-rs 
- `validate_maker_order_matches_taker_order`, `get_amount_with_fee`, and `get_seat_percentage_of_fees`

Will continue add more functions that are in Typescript sdk to Rust sdk 